### PR TITLE
fix(terraform-provider-jans): update terraform module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.7.1](https://github.com/JanssenProject/terraform-provider-jans/compare/v0.7.0...v0.7.1) (2023-06-05)
+
+
+### Bug Fixes
+
+* changed agama deployment file hash to be required, instead of computed 
+* changed agama deployment file hash to be required, instead of computed 
+
 ## [0.7.0](https://github.com/JanssenProject/terraform-provider-jans/compare/v0.6.0...v0.7.0) (2023-05-23)
 
 

--- a/docs/resources/agama_deployment.md
+++ b/docs/resources/agama_deployment.md
@@ -18,13 +18,13 @@ Resource for managing agama authentication flow deployments.
 ### Required
 
 - `deployment_file` (String) Path to the deployment file (in zip format)
+- `deployment_file_hash` (String) Hash of the deployment file, used to detect changes.
 - `name` (String) Agama project name
 
 ### Read-Only
 
 - `base_dn` (String) Agama deployment base DN
 - `created_at` (String) Agama deployment creation time
-- `deployment_file_hash` (String) Hash of the deployment file, used to detect changes.
 - `dn` (String) Agama deployment DN
 - `id` (String) Agama deployment ID
 - `task_active` (Boolean) Boolean value with default value false.


### PR DESCRIPTION
 Features

* add missing attributes for fido2 app configuration updates 


### Bug Fixes

* fido2 config error and put operation 
* fixed request for sending binary data 
* update method name to match naming scheme 
* updated organisation mappings 
Closes #5156, 