### PR TITLE
fix: bug in resource_app_configuration.go

### DIFF
--- a/provider/resource_app_configuration.go
+++ b/provider/resource_app_configuration.go
@@ -1702,7 +1702,7 @@ func resourceAppConfiguration() *schema.Resource {
 				Optional:    true,
 				Description: "The number of registration requests allowed per interval.",
 			},
-			"rateLimitRegistrationPeriodInSeconds": {
+			"rate_limit_registration_period_in_seconds": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "The time period in seconds for the rate limit.",


### PR DESCRIPTION
rename to rate_limit_registration_period_in_seconds