### PR TITLE
docs: add PR template and issue templates in the terraform repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,18 @@
+---
+name: Bug Report
+about: Report a bug in the Janssen Terraform provider
+title: '[BUG] '
+labels: bug, terraform
+assignees: ''
+
+---
+
+## Bug Report
+
+### Description
+Provide a clear and concise description of the bug (e.g., unexpected error during plan/apply, incorrect resource state, provider crash).
+
+### Terraform Configuration
+```hcl
+# Paste your relevant Terraform configuration here (provider block + affected resources)
+# Remove any sensitive values (URLs, tokens, secrets) before posting!

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,10 +7,13 @@ assignees: ''
 
 ---
 
+
 ## Bug Report
+
 
 ### Description
 Provide a clear and concise description of the bug (e.g., unexpected error during plan/apply, incorrect resource state, provider crash).
+
 
 ### Terraform Configuration
 ```hcl

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,21 +1,48 @@
 ---
 name: Bug Report
-about: Report a bug in the Janssen Terraform provider
-title: '[BUG] '
-labels: bug, terraform
+about: Report a bug or unexpected behavior in the Terraform provider
+title: "[BUG] "
+labels: bug
 assignees: ''
-
 ---
-
 
 ## Bug Report
 
-
 ### Description
+
 Provide a clear and concise description of the bug (e.g., unexpected error during plan/apply, incorrect resource state, provider crash).
 
-
 ### Terraform Configuration
-```hcl
+````hcl
 # Paste your relevant Terraform configuration here (provider block + affected resources)
 # Remove any sensitive values (URLs, tokens, secrets) before posting!
+````
+
+### Expected Behavior
+
+What did you expect to happen?
+
+### Actual Behavior
+
+What actually happened? Include error messages or logs.
+
+### Steps to Reproduce
+
+1. Run `terraform init`
+2. Run `terraform plan` or `terraform apply`
+3. Observe error
+
+### Environment
+
+- **Provider Version**: (e.g., v0.1.0)
+- **Janssen Server Version**: (e.g., v1.2.0)
+- **Terraform Version**: (e.g., v1.9.0)
+- **OS**: (e.g., Linux, macOS)
+
+### Logs/Screenshots
+
+Attach relevant logs (set `TF_LOG=DEBUG` for verbose output) or screenshots.
+
+### Additional Context
+
+Any other information that might help diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/development-item.md
+++ b/.github/ISSUE_TEMPLATE/development-item.md
@@ -9,6 +9,7 @@ assignees: ''
 
 ## Feature Request
 
+
 ### Description
 Provide a clear and concise description of the new feature or improvement.
 

--- a/.github/ISSUE_TEMPLATE/development-item.md
+++ b/.github/ISSUE_TEMPLATE/development-item.md
@@ -1,0 +1,34 @@
+---
+name: Feature Request
+about: Propose a new resource, data source, or improvement for the Janssen Terraform provider
+title: '[FEATURE] '
+labels: enhancement, terraform
+assignees: ''
+
+---
+
+## Feature Request
+
+### Description
+Provide a clear and concise description of the new feature or improvement.
+
+### Resource/Data Source Suggestion
+- Resource name: `jans_xxx` (e.g., `jans_scope`, `jans_acr`)
+- Data source name: `jans_xxx` (if applicable)
+
+### Why is this needed?
+Explain the use case (e.g., "Managing OAuth scopes via Terraform is currently manual; this would enable full IaC for Janssen configs").
+
+### Proposed Changes
+List the specific fields/arguments:
+- `field1`: Description (type)
+- `field2`: Description (type, optional/computed)
+
+### Acceptance Criteria
+- Provider implements the resource/data source
+- Acceptance tests pass
+- Documentation updated
+- Example usage in README
+
+### Additional Context
+Links to Janssen API docs, related issues, or existing resources that could be extended.

--- a/.github/ISSUE_TEMPLATE/development-item.md
+++ b/.github/ISSUE_TEMPLATE/development-item.md
@@ -1,35 +1,39 @@
 ---
-name: Feature Request
-about: Propose a new resource, data source, or improvement for the Janssen Terraform provider
-title: '[FEATURE] '
-labels: enhancement, terraform
+name: Development / Feature Request
+about: Suggest a new resource, data source, or feature
+title: "[FEATURE] "
+labels: enhancement
 assignees: ''
-
 ---
 
 ## Feature Request
 
-
 ### Description
+
 Provide a clear and concise description of the new feature or improvement.
 
 ### Resource/Data Source Suggestion
+
 - Resource name: `jans_xxx` (e.g., `jans_scope`, `jans_acr`)
 - Data source name: `jans_xxx` (if applicable)
 
 ### Why is this needed?
+
 Explain the use case (e.g., "Managing OAuth scopes via Terraform is currently manual; this would enable full IaC for Janssen configs").
 
 ### Proposed Changes
+
 List the specific fields/arguments:
 - `field1`: Description (type)
 - `field2`: Description (type, optional/computed)
 
 ### Acceptance Criteria
+
 - Provider implements the resource/data source
 - Acceptance tests pass
 - Documentation updated
 - Example usage in README
 
 ### Additional Context
+
 Links to Janssen API docs, related issues, or existing resources that could be extended.

--- a/.github/ISSUE_TEMPLATE/failing-tests.md
+++ b/.github/ISSUE_TEMPLATE/failing-tests.md
@@ -1,0 +1,39 @@
+---
+name: Failing Test / Acceptance Test Failure
+about: Report a failing acceptance test in the Janssen Terraform provider
+title: '[TEST] '
+labels: test-failure, terraform
+assignees: ''
+
+---
+
+## Failing Test
+
+### Description
+Describe the failing test and its purpose (e.g., "Test for creating a new client fails with 401").
+
+### Test Details
+- **Test Name**: (e.g., `TestAccJansClient_basic`)
+- **Test File/Location**: (e.g., `jans/resource_jans_client_test.go`)
+
+### Steps to Reproduce
+1. Run `make testacc TESTARGS='-run=TestAccJansClient'`
+2. Observe failure
+
+### Expected Behavior
+Describe what the test should do when passing.
+
+### Actual Behavior
+Include error message/stack trace.
+
+### Environment
+- **Provider Version**: (e.g., v0.1.0)
+- **Janssen Server Version**: (e.g., v1.2.0)
+- **OS**: (e.g., Linux)
+- **Terraform Version**: (e.g., v1.9.0)
+
+### Logs/Screenshots
+Attach test output or screenshots of failure.
+
+### Additional Context
+Any recent changes or related issues?

--- a/.github/ISSUE_TEMPLATE/failing-tests.md
+++ b/.github/ISSUE_TEMPLATE/failing-tests.md
@@ -9,22 +9,28 @@ assignees: ''
 
 ## Failing Test
 
+
 ### Description
 Describe the failing test and its purpose (e.g., "Test for creating a new client fails with 401").
+
 
 ### Test Details
 - **Test Name**: (e.g., `TestAccJansClient_basic`)
 - **Test File/Location**: (e.g., `jans/resource_jans_client_test.go`)
 
+
 ### Steps to Reproduce
 1. Run `make testacc TESTARGS='-run=TestAccJansClient'`
 2. Observe failure
 
+
 ### Expected Behavior
 Describe what the test should do when passing.
 
+
 ### Actual Behavior
 Include error message/stack trace.
+
 
 ### Environment
 - **Provider Version**: (e.g., v0.1.0)
@@ -32,8 +38,10 @@ Include error message/stack trace.
 - **OS**: (e.g., Linux)
 - **Terraform Version**: (e.g., v1.9.0)
 
+
 ### Logs/Screenshots
 Attach test output or screenshots of failure.
+
 
 ### Additional Context
 Any recent changes or related issues?

--- a/.github/ISSUE_TEMPLATE/failing-tests.md
+++ b/.github/ISSUE_TEMPLATE/failing-tests.md
@@ -1,47 +1,46 @@
 ---
-name: Failing Test / Acceptance Test Failure
-about: Report a failing acceptance test in the Janssen Terraform provider
-title: '[TEST] '
-labels: test-failure, terraform
+name: Failing Tests
+about: Report acceptance tests that are failing
+title: "[TEST] "
+labels: bug, tests
 assignees: ''
-
 ---
 
 ## Failing Test
 
-
 ### Description
+
 Describe the failing test and its purpose (e.g., "Test for creating a new client fails with 401").
 
-
 ### Test Details
+
 - **Test Name**: (e.g., `TestAccJansClient_basic`)
 - **Test File/Location**: (e.g., `jans/resource_jans_client_test.go`)
 
-
 ### Steps to Reproduce
+
 1. Run `make testacc TESTARGS='-run=TestAccJansClient'`
 2. Observe failure
 
-
 ### Expected Behavior
+
 Describe what the test should do when passing.
 
-
 ### Actual Behavior
+
 Include error message/stack trace.
 
-
 ### Environment
+
 - **Provider Version**: (e.g., v0.1.0)
 - **Janssen Server Version**: (e.g., v1.2.0)
 - **OS**: (e.g., Linux)
 - **Terraform Version**: (e.g., v1.9.0)
 
-
 ### Logs/Screenshots
+
 Attach test output or screenshots of failure.
 
-
 ### Additional Context
+
 Any recent changes or related issues?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 ## What did we change?
 
+
 ## Why are we doing this?
+
 
 ## How was it tested?
 - [ ] Locally (`terraform init`, `terraform plan`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## What did we change?
+
+## Why are we doing this?
+
+## How was it tested?
+- [ ] Locally (`terraform init`, `terraform plan`)
+- [ ] Development Environment
+- [ ] Not needed, changes very basic
+- [ ] Documentation updated

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+# Pull Request
+
 ## What did we change?
 
 
@@ -5,6 +7,7 @@
 
 
 ## How was it tested?
+
 - [ ] Locally (`terraform init`, `terraform plan`)
 - [ ] Development Environment
 - [ ] Not needed, changes very basic


### PR DESCRIPTION
## What did we change?
- I've added a PR template form and issue template files for reporting a bug, new feature or failing test.

## Why are we doing this?
- Auto populated fields makes reporting easy on the user and structured for the team to know what really matters.

## How was it tested?
- [ ] Locally (`terraform init`, `terraform plan`)
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Documentation updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added standardized issue templates for bug reports, feature requests, and failing-test reports with guided sections to capture description, reproduction steps, environment, logs/screenshots, proposed changes, and acceptance criteria.
  * Added a pull request template with common sections and a testing checklist to ensure consistent PR descriptions and validation steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->